### PR TITLE
Update OVMF code retrieval method for , to reflect limines working me…

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -153,12 +153,10 @@ run-hdd-bios: $(IMAGE_NAME).hdd
 		$(QEMUFLAGS)
 
 ovmf/ovmf-code-$(ARCH).fd:
+	curl -L https://github.com/osdev0/edk2-ovmf-nightly/releases/latest/download/edk2-ovmf.tar.gz | gunzip | tar -xf -
 	mkdir -p ovmf
-	curl -Lo $@ https://github.com/osdev0/edk2-ovmf-nightly/releases/latest/download/ovmf-code-$(ARCH).fd
-	case "$(ARCH)" in \
-		aarch64) dd if=/dev/zero of=$@ bs=1 count=0 seek=67108864 2>/dev/null;; \
-		riscv64) dd if=/dev/zero of=$@ bs=1 count=0 seek=33554432 2>/dev/null;; \
-	esac
+	mv edk2-ovmf/ovmf-code-$(ARCH).fd ovmf/ovmf-code-$(ARCH).fd
+	rm -rf edk2-ovmf
 
 limine/limine:
 	rm -rf limine


### PR DESCRIPTION
…thod

Replace direct download of ovmf-code with extraction from edk2-ovmf tarball. since the old path returns a 404 now